### PR TITLE
Fixes for split screen, multiplayer, rendering calls & added basic...

### DIFF
--- a/NPCMapLocations/ModMain.cs
+++ b/NPCMapLocations/ModMain.cs
@@ -11,6 +11,7 @@ using StardewValley.Locations;
 using StardewValley.Menus;
 using StardewValley.Quests;
 using StardewValley.Characters;
+using StardewModdingAPI.Utilities;
 
 namespace NPCMapLocations
 {
@@ -23,20 +24,22 @@ namespace NPCMapLocations
     public static Texture2D Map;
     public static Vector2 UNKNOWN = new Vector2(-9999, -9999);
 
-    private Texture2D BuildingMarkers;  
-    private Dictionary<string, MapVector[]> MapVectors;
-    private ModMinimap Minimap;
-    private Dictionary<string, NpcMarker> NpcMarkers;
-    private Dictionary<string, bool> ConditionalNpcs;
-    private bool hasOpenedMap;
-    private bool isModMapOpen;
+    private readonly PerScreen<Texture2D> BuildingMarkers = new PerScreen<Texture2D>();
+    private readonly PerScreen<Dictionary<string, MapVector[]>> MapVectors = new PerScreen<Dictionary<string, MapVector[]>>();
+    private readonly PerScreen<ModMinimap> Minimap = new PerScreen<ModMinimap>();
+    private readonly PerScreen<Dictionary<string, NpcMarker>> NpcMarkers = new PerScreen<Dictionary<string, NpcMarker>>();
+    private readonly PerScreen<Dictionary<string, bool>> ConditionalNpcs = new PerScreen<Dictionary<string, bool>>();
+    private readonly PerScreen<bool> hasOpenedMap = new PerScreen<bool>();
+    private readonly PerScreen<bool> isModMapOpen = new PerScreen<bool>();
 
     // Multiplayer
-    private Dictionary<long, FarmerMarker> FarmerMarkers;
+    private readonly PerScreen<Dictionary<long, FarmerMarker>> FarmerMarkers = new PerScreen<Dictionary<long, FarmerMarker>>();
+    private static long hostId;
+    private static List<long> playerIds;
 
     // Customizations/Custom mods
-    private string MapSeason;
-    private ModCustomizations Customizations;
+    private static string MapSeason;
+    private static ModCustomizations Customizations;
 
     // Debugging
     private static bool DEBUG_MODE;
@@ -59,14 +62,14 @@ namespace NPCMapLocations
         MapSeason = "spring";
       }
 
-      if (!File.Exists(Path.Combine(ModMain.Helper.DirectoryPath, Customizations.MapsPath, $"{this.MapSeason}_map.png")))
+      if (!File.Exists(Path.Combine(ModMain.Helper.DirectoryPath, Customizations.MapsPath, $"{MapSeason}_map.png")))
       {
         Monitor.Log("Seasonal maps not provided. Defaulted to spring.", LogLevel.Debug);
         MapSeason = null; // Set to null so that cache is not invalidate when game season changes
       }
 
       // Replace map page
-      string filename = this.MapSeason == null ? "spring_map.png" : $"{this.MapSeason}_map.png";
+      string filename = MapSeason == null ? "spring_map.png" : $"{MapSeason}_map.png";
 
       bool useRecolor = Customizations.MapsPath != null && File.Exists(Path.Combine(ModMain.Helper.DirectoryPath, Customizations.MapsPath, filename));
       map = useRecolor
@@ -81,6 +84,8 @@ namespace NPCMapLocations
 
     public override void Entry(IModHelper helper)
     {
+      if (!Context.IsMainPlayer && Context.IsSplitScreen) return;
+
       Helper = helper;
       IMonitor = Monitor;
       Globals = Helper.Data.ReadJsonFile<GlobalConfig>("config/globals.json") ?? new GlobalConfig();
@@ -94,6 +99,7 @@ namespace NPCMapLocations
       Helper.Events.Player.Warped += Player_Warped;
       Helper.Events.Display.MenuChanged += Display_MenuChanged;
       Helper.Events.Display.RenderingHud += Display_RenderingHud;
+      Helper.Events.Display.RenderedWorld += Display_RenderedWorld;
       Helper.Events.Display.Rendered += Display_Rendered;
       Helper.Events.Display.WindowResized += Display_WindowResized;
       Helper.Events.Multiplayer.ModMessageReceived += Multiplayer_ModMessageReceived;
@@ -104,26 +110,43 @@ namespace NPCMapLocations
     {
       Config = Helper.Data.ReadJsonFile<PlayerConfig>($"config/{Constants.SaveFolderName}.json") ?? new PlayerConfig();
 
+      if (Context.IsMainPlayer)
+      {
+        playerIds = new List<long>();
+      }
+      else if (!Context.IsMainPlayer)
+      {
+        // Determine host ID
+        foreach (IMultiplayerPeer peer in Helper.Multiplayer.GetConnectedPlayers())
+        {
+          if (peer.IsHost)
+          {
+            hostId = peer.PlayerID;
+            break;
+          }
+        }
+      }
+
       // Load customizations
       // Initialize these early for multiplayer sync
-      NpcMarkers = new Dictionary<string, NpcMarker>();
+      NpcMarkers.Value = new Dictionary<string, NpcMarker>();
       Customizations = new ModCustomizations();
       Customizations.LoadCustomData();
 
       // Let host know farmhand is ready to receive updates
       if (Context.IsMultiplayer && !Context.IsMainPlayer)
       {
-        Helper.Multiplayer.SendMessage(true, "PlayerReady", modIDs: new string[] { ModManifest.UniqueID });
+        Helper.Multiplayer.SendMessage(true, "PlayerReady", modIDs: new string[] { ModManifest.UniqueID }, playerIDs: new long[] { hostId });
       }
 
       // Load farm buildings
       try
       {
-        BuildingMarkers = Helper.Content.Load<Texture2D>(Path.Combine(Customizations.MapsPath, "buildings.png"));
+        BuildingMarkers.Value = Helper.Content.Load<Texture2D>(Path.Combine(Customizations.MapsPath, "buildings.png"));
       }
       catch
       {
-        BuildingMarkers = null;
+        BuildingMarkers.Value = null;
       }
 
       // Get season for map
@@ -135,21 +158,21 @@ namespace NPCMapLocations
       DEBUG_MODE = Globals.DEBUG_MODE && !Context.IsMultiplayer;
 
       // NPCs that player should meet before being shown
-      ConditionalNpcs = new Dictionary<string, bool>();
+      ConditionalNpcs.Value = new Dictionary<string, bool>();
       foreach (var npcName in ModConstants.ConditionalNpcs)
       {
-        ConditionalNpcs[npcName] = Game1.player.friendshipData.ContainsKey(npcName);
+        ConditionalNpcs.Value[npcName] = Game1.player.friendshipData.ContainsKey(npcName);
       }
 
-      MapVectors = ModConstants.MapVectors;
+      MapVectors.Value = ModConstants.MapVectors;
 
       // Add custom map vectors from customlocations.json
       foreach (var locVectors in Customizations.MapVectors)
       {
-        if (MapVectors.TryGetValue(locVectors.Key, out var mapVectors))
-          MapVectors[locVectors.Key] = locVectors.Value;
+        if (MapVectors.Value.TryGetValue(locVectors.Key, out var mapVectors))
+          MapVectors.Value[locVectors.Key] = locVectors.Value;
         else
-          MapVectors.Add(locVectors.Key, locVectors.Value);
+          MapVectors.Value.Add(locVectors.Key, locVectors.Value);
       }
 
       // Get context of all locations (indoor, outdoor, relativity)
@@ -159,8 +182,8 @@ namespace NPCMapLocations
       // Log any custom locations not in customlocations.json
       foreach (var locCtx in LocationUtil.LocationContexts)
       {
-        if ((locCtx.Value.Root == null && !MapVectors.ContainsKey(locCtx.Key))
-          || (locCtx.Value.Root != null && !MapVectors.ContainsKey(locCtx.Value.Root))
+        if ((locCtx.Value.Root == null && !MapVectors.Value.ContainsKey(locCtx.Key))
+          || (locCtx.Value.Root != null && !MapVectors.Value.ContainsKey(locCtx.Value.Root))
         )
         {
           if (!alertFlags.Contains("UnknownLocation:" + locCtx.Key))
@@ -290,17 +313,17 @@ namespace NPCMapLocations
       if (!Context.IsWorldReady) return;
 
       // Minimap dragging
-      if (Config.ShowMinimap && Minimap != null)
+      if (Config.ShowMinimap && Minimap.Value != null)
       {
-        if (Minimap.isHoveringDragZone() && e.Button == SButton.MouseRight)
+        if (Minimap.Value.isHoveringDragZone() && e.Button == SButton.MouseRight)
         {
-          MouseUtil.HandleMouseDown(() => Minimap.HandleMouseDown());
+          MouseUtil.HandleMouseDown(() => Minimap.Value.HandleMouseDown());
         }
       }
 
       // Debug DnD
       if
-        (DEBUG_MODE && e.Button == SButton.MouseRight && isModMapOpen)
+        (DEBUG_MODE && e.Button == SButton.MouseRight && isModMapOpen.Value)
       {
         MouseUtil.HandleMouseDown();
       }
@@ -324,18 +347,18 @@ namespace NPCMapLocations
     {
       if (!Context.IsWorldReady) return;
 
-      if (DEBUG_MODE && e.Button == SButton.MouseRight && isModMapOpen)
+      if (DEBUG_MODE && e.Button == SButton.MouseRight && isModMapOpen.Value)
       {
         MouseUtil.HandleMouseRelease();
       }
-      else if (Minimap != null)
+      else if (Minimap.Value != null)
       {
         if (Game1.activeClickableMenu is ModMenu && e.Button == SButton.MouseLeft) {
-          Minimap.Resize();
+          Minimap.Value.Resize();
         }
         else if (Game1.activeClickableMenu == null && e.Button == SButton.MouseRight)
         {
-          MouseUtil.HandleMouseRelease(() => Minimap.HandleMouseRelease());
+          MouseUtil.HandleMouseRelease(() => Minimap.Value.HandleMouseRelease());
         }
       }
     }
@@ -346,8 +369,8 @@ namespace NPCMapLocations
       if (menu.currentTab != ModConstants.MapTabIndex) return;
       if (input.ToString().Equals(Globals.MenuKey) || input is SButton.ControllerY)
         Game1.activeClickableMenu = new ModMenu(
-          NpcMarkers,
-          ConditionalNpcs
+          NpcMarkers.Value,
+          ConditionalNpcs.Value
         );
 
       if (input.ToString().Equals(Globals.TooltipKey) || input is SButton.RightShoulder)
@@ -375,19 +398,19 @@ namespace NPCMapLocations
     private void GameLoop_DayStarted(object sender = null, DayStartedEventArgs e = null)
     {
       // Check for travelining merchant day
-      if (ConditionalNpcs.ContainsKey("Merchant") && ConditionalNpcs["Merchant"]) {
-        ConditionalNpcs["Merchant"] = ((Forest)Game1.getLocationFromName("Forest")).travelingMerchantDay;
+      if (ConditionalNpcs.Value.ContainsKey("Merchant") && ConditionalNpcs.Value["Merchant"]) {
+        ConditionalNpcs.Value["Merchant"] = ((Forest)Game1.getLocationFromName("Forest")).travelingMerchantDay;
       }
 
       ResetMarkers();
       UpdateMarkers(true);
 
-      Minimap = new ModMinimap(
-        NpcMarkers,
-        ConditionalNpcs,
-        FarmerMarkers,
+      Minimap.Value = new ModMinimap(
+        NpcMarkers.Value,
+        ConditionalNpcs.Value,
+        FarmerMarkers.Value,
         FarmBuildings,
-        BuildingMarkers,
+        BuildingMarkers.Value,
         Customizations
       );
     }
@@ -400,8 +423,8 @@ namespace NPCMapLocations
 
     private void ResetMarkers()
     {
-      NpcMarkers = new Dictionary<string, NpcMarker>();
-      if (Context.IsMultiplayer) FarmerMarkers = new Dictionary<long, FarmerMarker>();
+      NpcMarkers.Value = new Dictionary<string, NpcMarker>();
+      FarmerMarkers.Value = new Dictionary<long, FarmerMarker>();
 
       if (!Context.IsMultiplayer || Context.IsMainPlayer)
       {
@@ -424,7 +447,7 @@ namespace NPCMapLocations
             offset = 0;
           }
 
-          if (!NpcMarkers.ContainsKey(npc.Name))
+          if (!NpcMarkers.Value.ContainsKey(npc.Name))
           {
             var newMarker = new NpcMarker()
             {
@@ -443,7 +466,7 @@ namespace NPCMapLocations
               newMarker.Sprite = npc.Sprite.Texture;
             }
 
-            NpcMarkers.Add(npc.Name, newMarker);
+            NpcMarkers.Value.Add(npc.Name, newMarker);
           }
         }
       }
@@ -457,11 +480,11 @@ namespace NPCMapLocations
       // Half-second tick
       if (e.IsMultipleOf(30))
       {
-        var updateForMinimap = Config.ShowMinimap && Minimap != null;
+        var updateForMinimap = Config.ShowMinimap && Minimap.Value != null;
 
         if (updateForMinimap)
         {
-          Minimap.Update();
+          Minimap.Value.Update();
         }
 
         UpdateMarkers(updateForMinimap | Context.IsMainPlayer);
@@ -471,7 +494,7 @@ namespace NPCMapLocations
         {
           var syncedMarkers = new Dictionary<string, SyncedNpcMarker>();
 
-          foreach (var npcMarker in NpcMarkers)
+          foreach (var npcMarker in NpcMarkers.Value)
           {
             syncedMarkers.Add(npcMarker.Key, new SyncedNpcMarker()
             {
@@ -484,7 +507,7 @@ namespace NPCMapLocations
             });
           }
 
-          Helper.Multiplayer.SendMessage(syncedMarkers, "SyncedNpcMarkers", modIDs: new string[] { ModManifest.UniqueID });
+          Helper.Multiplayer.SendMessage(syncedMarkers, "SyncedNpcMarkers", modIDs: new string[] { ModManifest.UniqueID }, playerIDs: playerIds.ToArray());
         }
       }
 
@@ -506,35 +529,35 @@ namespace NPCMapLocations
             Monitor.Log("Failed to update map for current season.", LogLevel.Error);
           }
 
-          Minimap?.UpdateMapForSeason();
+          Minimap.Value?.UpdateMapForSeason();
         }
 
         // Check if conditional NPCs have been talked to
         foreach (var npcName in ModConstants.ConditionalNpcs)
         {
-          if (ConditionalNpcs[npcName]) continue;
+          if (ConditionalNpcs.Value[npcName]) continue;
           
-          ConditionalNpcs[npcName] = Game1.player.friendshipData.ContainsKey(npcName);
+          ConditionalNpcs.Value[npcName] = Game1.player.friendshipData.ContainsKey(npcName);
         }
       }
 
       // Update tick
-      if (Config.ShowMinimap && Minimap != null && Minimap.isHoveringDragZone() && Helper.Input.GetState(SButton.MouseRight) == SButtonState.Held)
+      if (Config.ShowMinimap && Minimap.Value != null && Minimap.Value.isHoveringDragZone() && Helper.Input.GetState(SButton.MouseRight) == SButtonState.Held)
       {
-        Minimap.HandleMouseDrag();
+        Minimap.Value.HandleMouseDrag();
       }
 
       if (Game1.activeClickableMenu == null || !(Game1.activeClickableMenu is GameMenu gameMenu))
       {
-        isModMapOpen = false;
+        isModMapOpen.Value = false;
         return;
       }
 
-      hasOpenedMap =
+      hasOpenedMap.Value =
         gameMenu.currentTab == ModConstants.MapTabIndex; // When map accessed by switching GameMenu tab or pressing M
-      isModMapOpen = hasOpenedMap ? isModMapOpen : hasOpenedMap; // When vanilla MapPage is replaced by ModMap
+      isModMapOpen.Value = hasOpenedMap.Value ? isModMapOpen.Value : hasOpenedMap.Value; // When vanilla MapPage is replaced by ModMap
 
-      if (hasOpenedMap && !isModMapOpen) // Only run once on map open
+      if (hasOpenedMap.Value && !isModMapOpen.Value) // Only run once on map open
         OpenModMap();
     }
 
@@ -547,7 +570,13 @@ namespace NPCMapLocations
           case "PlayerReady":
             if (Context.IsMainPlayer)
             {
-              Helper.Multiplayer.SendMessage(Customizations.Names, "SyncedNames", modIDs: new string[] { ModManifest.UniqueID });
+              if (playerIds == null)
+              {
+                playerIds = new List<long>();
+              }
+              playerIds.Add(e.FromPlayerID);
+
+              Helper.Multiplayer.SendMessage(Customizations.Names, "SyncedNames", modIDs: new string[] { ModManifest.UniqueID }, playerIDs: playerIds.ToArray());
             }
             break;
           case "SyncedNames":
@@ -558,7 +587,7 @@ namespace NPCMapLocations
             }
             break;
           case "SyncedNpcMarkers":
-            if (NpcMarkers == null) return;
+            if (NpcMarkers.Value == null) return;
 
             var syncedNpcMarkers = e.ReadAs<Dictionary<string, SyncedNpcMarker>>();
             foreach (var syncedMarker in syncedNpcMarkers)
@@ -568,7 +597,7 @@ namespace NPCMapLocations
                 offset = 0;
               }
 
-              if (NpcMarkers.TryGetValue(syncedMarker.Key, out var npcMarker))
+              if (NpcMarkers.Value.TryGetValue(syncedMarker.Key, out var npcMarker))
               {
                 npcMarker.LocationName = syncedMarker.Value.LocationName;
                 npcMarker.MapX = syncedMarker.Value.MapX;
@@ -587,7 +616,14 @@ namespace NPCMapLocations
                 {
                   if (syncedMarker.Value.Type == Character.Villager)
                   {
-                    npcMarker.Sprite = new AnimatedSprite($"Characters\\{name}", 0, 16, 32).Texture;
+                    if (name == "Leo")
+                    {
+                      npcMarker.Sprite = new AnimatedSprite($"Characters\\ParrotBoy", 0, 16, 32).Texture;
+                    }
+                    else
+                    {
+                      npcMarker.Sprite = new AnimatedSprite($"Characters\\{name}", 0, 16, 32).Texture;
+                    }
                   }
                   else
                   {
@@ -622,7 +658,14 @@ namespace NPCMapLocations
                 {
                   if (syncedMarker.Value.Type == Character.Villager)
                   {
-                    newMarker.Sprite = new AnimatedSprite($"Characters\\{name}", 0, 16, 32).Texture;
+                    if (name == "Leo")
+                    {
+                      npcMarker.Sprite = new AnimatedSprite($"Characters\\ParrotBoy", 0, 16, 32).Texture;
+                    }
+                    else
+                    {
+                      npcMarker.Sprite = new AnimatedSprite($"Characters\\{name}", 0, 16, 32).Texture;
+                    }
                   }
                   else
                   {
@@ -636,7 +679,7 @@ namespace NPCMapLocations
                 }
 
 
-                NpcMarkers.Add(syncedMarker.Key, newMarker);
+                NpcMarkers.Value.Add(syncedMarker.Key, newMarker);
               }
             }
             break;
@@ -650,7 +693,7 @@ namespace NPCMapLocations
     {
       if (!(Game1.activeClickableMenu is GameMenu gameMenu)) return;
 
-      isModMapOpen = true;
+      isModMapOpen.Value = true;
 
       var pages = Helper.Reflection
         .GetField<List<IClickableMenu>>(gameMenu, "pages").GetValue();
@@ -658,18 +701,18 @@ namespace NPCMapLocations
       // Changing the page in GameMenu instead of changing Game1.activeClickableMenu
       // allows for better compatibility with other mods that use MapPage
       pages[ModConstants.MapTabIndex] = new ModMapPage(
-        NpcMarkers,
-        ConditionalNpcs,
-        FarmerMarkers,
+        NpcMarkers.Value,
+        ConditionalNpcs.Value,
+        FarmerMarkers.Value,
         FarmBuildings,
-        BuildingMarkers,
+        BuildingMarkers.Value,
         Customizations
       );
     }
 
     private void UpdateMarkers(bool forceUpdate = false)
     {
-      if (isModMapOpen || forceUpdate)
+      if (isModMapOpen.Value || forceUpdate)
       {
         if (!Context.IsMultiplayer || Context.IsMainPlayer)
         {
@@ -688,20 +731,28 @@ namespace NPCMapLocations
     // Update NPC marker data and names on hover
     private void UpdateNpcs()
     {
-      if (NpcMarkers == null) return;
+      if (NpcMarkers.Value == null) return;
 
-      foreach (var npc in GetVillagers())
+      List<NPC> npc_list = GetVillagers();
+
+      // If player is riding a horse, add it to list
+      if (Game1.player.isRidingHorse())
       {
-        if (!NpcMarkers.TryGetValue(npc.Name, out var npcMarker)
+        npc_list.Add(Game1.player.mount);
+      }
+
+      foreach (var npc in npc_list)
+      {
+        if (!NpcMarkers.Value.TryGetValue(npc.Name, out var npcMarker)
           || npc.currentLocation == null)
         {
           continue;
         }
 
-        // Hide horse if being ridden
-        if (npc is Horse)
+        /* // Hide horse if being ridden
+        if (npc is Horse horse)
         {
-          var isRiding = false;
+          /*var isRiding = false;
 
           // If horse is being ridden, hide it
           foreach (var farmer in Game1.getOnlineFarmers())
@@ -713,13 +764,13 @@ namespace NPCMapLocations
             }
           }
 
-          if (isRiding)
+          if (horse.rider != null)
           {
             npcMarker.MapX = -9999;
             npcMarker.MapY = -9999;
             continue;
           }
-        }
+        } */
 
         string locationName = npc.currentLocation.uniqueName.Value ?? npc.currentLocation.Name;
         npcMarker.LocationName = locationName;
@@ -800,9 +851,9 @@ namespace NPCMapLocations
     // Update npc marker properties only relevant to farmhand
     private void UpdateNpcsFarmhand()
     {
-      if (NpcMarkers == null) return;
+      if (NpcMarkers.Value == null) return;
 
-      foreach (var npcMarker in NpcMarkers)
+      foreach (var npcMarker in NpcMarkers.Value)
       {
         var name = npcMarker.Key;
         var marker = npcMarker.Value;
@@ -891,7 +942,7 @@ namespace NPCMapLocations
           Customizations.LocationBlacklist
         );
 
-        if (FarmerMarkers.TryGetValue(farmer.UniqueMultiplayerID, out var farMarker))
+        if (FarmerMarkers.Value.TryGetValue(farmer.UniqueMultiplayerID, out var farMarker))
         {
           var deltaX = farmerLoc.X - farMarker.PrevMapX;
           var deltaY = farmerLoc.Y - farMarker.PrevMapY;
@@ -899,9 +950,9 @@ namespace NPCMapLocations
           // Location changes before tile position, causing farmhands to blink
           // to the wrong position upon entering new location. Handle this in draw.
           if (locationName == farMarker.LocationName && MathHelper.Distance(deltaX, deltaY) > 15)
-            FarmerMarkers[farmerId].DrawDelay = 1;
+            FarmerMarkers.Value[farmerId].DrawDelay = 1;
           else if (farMarker.DrawDelay > 0)
-            FarmerMarkers[farmerId].DrawDelay--;
+            FarmerMarkers.Value[farmerId].DrawDelay--;
         }
         else
         {
@@ -911,17 +962,17 @@ namespace NPCMapLocations
             DrawDelay = 0
           };
 
-          FarmerMarkers.Add(farmerId, newMarker);
+          FarmerMarkers.Value.Add(farmerId, newMarker);
         }
 
 
-        FarmerMarkers[farmerId].MapX = (int)farmerLoc.X;
-        FarmerMarkers[farmerId].MapY = (int)farmerLoc.Y;
-        FarmerMarkers[farmerId].PrevMapX = (int)farmerLoc.X;
-        FarmerMarkers[farmerId].PrevMapY = (int)farmerLoc.Y;
-        FarmerMarkers[farmerId].LocationName = locationName;
-        FarmerMarkers[farmerId].MapX = (int)farmerLoc.X;
-        FarmerMarkers[farmerId].MapY = (int)farmerLoc.Y;
+        FarmerMarkers.Value[farmerId].MapX = (int)farmerLoc.X;
+        FarmerMarkers.Value[farmerId].MapY = (int)farmerLoc.Y;
+        FarmerMarkers.Value[farmerId].PrevMapX = (int)farmerLoc.X;
+        FarmerMarkers.Value[farmerId].PrevMapY = (int)farmerLoc.Y;
+        FarmerMarkers.Value[farmerId].LocationName = locationName;
+        FarmerMarkers.Value[farmerId].MapX = (int)farmerLoc.X;
+        FarmerMarkers.Value[farmerId].MapY = (int)farmerLoc.Y;
       }
     }
 
@@ -1065,9 +1116,9 @@ namespace NPCMapLocations
 
       UpdateMarkers(true);
       UpdateFarmBuildingLocs();
-      Minimap?.CheckOffsetForMap();
+      Minimap.Value?.CheckOffsetForMap();
 
-      if (isModMapOpen)
+      if (isModMapOpen.Value)
       {
         OpenModMap();
       }
@@ -1080,7 +1131,7 @@ namespace NPCMapLocations
 
       // Check for resize after mod menu closed
       if (e.OldMenu is ModMenu)
-        Minimap?.Resize();
+        Minimap.Value?.Resize();
     }
 
     private void Player_Warped(object sender, WarpedEventArgs e)
@@ -1091,14 +1142,17 @@ namespace NPCMapLocations
         Config.ShowMinimap = Config.ShowMinimap && !IsLocationBlacklisted(e.NewLocation.Name);
 
         // Check if map does not fill screen and adjust for black bars (ex. BusStop)
-        Minimap?.CheckOffsetForMap();
+        Minimap.Value?.CheckOffsetForMap();
       }
     }
 
     private void Display_RenderingHud(object sender, RenderingHudEventArgs e)
     {
-      if (Context.IsWorldReady && Config.ShowMinimap && Game1.displayHUD) Minimap?.DrawMiniMap();
+      if (Context.IsWorldReady && Config.ShowMinimap && Game1.displayHUD) Minimap.Value?.DrawMiniMap();
+    }
 
+    private void Display_RenderedWorld(object sender, RenderedWorldEventArgs e)
+    {
       // Highlight tile for debug mode
       if (DEBUG_MODE)
         Game1.spriteBatch.Draw(Game1.mouseCursors,
@@ -1128,7 +1182,7 @@ namespace NPCMapLocations
       var currMenu = Game1.activeClickableMenu is GameMenu ? (GameMenu)Game1.activeClickableMenu : null;
 
       // If map is open, show map position at cursor
-      if (isModMapOpen)
+      if (isModMapOpen.Value)
       {
         int borderWidth = 3;
         float borderOpacity = 0.75f;

--- a/NPCMapLocations/data/ModConstants.cs
+++ b/NPCMapLocations/data/ModConstants.cs
@@ -19,6 +19,7 @@ public static class ModConstants
     {
         {"Abigail", 3},
         {"Alex", 0},
+        {"Birdie", 6},
         {"Caroline", 2},
         {"Clint", -1},
         {"Demetrius", -2},
@@ -36,6 +37,7 @@ public static class ModConstants
         {"Kent", -1},
         {"Krobus", 0},
         {"Leah", 2},
+        {"Leo", 6},
         {"Lewis", 1},
         {"Linus", 6},
         {"Marlon", 2},
@@ -61,6 +63,7 @@ public static class ModConstants
       "Mister Qi",
       "Bouncer",
       "Henchman",
+      "Birdie",
       // "Gunther",
       // "Krobus",
       // "Dusty"
@@ -76,6 +79,7 @@ public static class ModConstants
       "Merchant", 
       "Sandy", 
       "Wizard",
+      "Leo",
   };
 
   // tileX and TileY (the first two values) are tile positions in the game for that location
@@ -188,11 +192,11 @@ public static class ModConstants
           }
       },
       {
-        "BeachNightMarket", new MapVector[]
-        {
-          new MapVector(726, 541, 0, 0),
-          new MapVector(997, 688, 104, 50)
-        }
+          "BeachNightMarket", new MapVector[]
+          {
+            new MapVector(726, 541, 0, 0),
+            new MapVector(997, 688, 104, 50)
+          }
       },
       {
           "LonelyStone", new MapVector[]
@@ -255,6 +259,52 @@ public static class ModConstants
           "WizardHouseBasement", new MapVector[]
           {
               new MapVector(263, 447),
+          }
+      },
+      {
+          "IslandSouth", new MapVector[]
+          {
+              new MapVector(1114, 676, 0, 10),
+              new MapVector(1140, 696, 42, 30),
+          }
+      },
+      {
+          "IslandSouthEast", new MapVector[]
+          {
+              new MapVector(1142, 678, 0, 0),
+              new MapVector(1167, 706, 34, 34),
+          }
+      },
+      {
+          "IslandEast", new MapVector[]
+          {
+              new MapVector(1166, 662),
+          }
+      },
+      {
+          "IslandShrine", new MapVector[]
+          {
+              new MapVector(1182, 652),
+          }
+      },
+      {
+          "IslandWest", new MapVector[]
+          {
+              new MapVector(1030, 660, 14, 4),
+              new MapVector(1105, 700, 108, 89),
+          }
+      },
+      {
+          "IslandNorth", new MapVector[]
+          {
+              new MapVector(1090, 615, 0, 0),
+              new MapVector(1156, 670, 69, 89),
+          }
+      },
+      {
+          "GingerIsland", new MapVector[]
+          {
+              new MapVector(1110, 640),
           }
       },
     };

--- a/NPCMapLocations/ui/ModMapPage.cs
+++ b/NPCMapLocations/ui/ModMapPage.cs
@@ -45,8 +45,8 @@ namespace NPCMapLocations
       Dictionary<string, KeyValuePair<string, Vector2>> farmBuildings,
       Texture2D buildingMarkers,
       ModCustomizations customizations
-    ) : base(Game1.viewport.Width / 2 - (800 + IClickableMenu.borderWidth * 2) / 2,
-      Game1.viewport.Height / 2 - (600 + IClickableMenu.borderWidth * 2) / 2, 800 + IClickableMenu.borderWidth * 2,
+    ) : base(Game1.uiViewport.Width / 2 - (800 + IClickableMenu.borderWidth * 2) / 2,
+      Game1.uiViewport.Height / 2 - (600 + IClickableMenu.borderWidth * 2) / 2, 800 + IClickableMenu.borderWidth * 2,
       600 + IClickableMenu.borderWidth * 2)
     {
       this.NpcMarkers = npcMarkers;
@@ -60,8 +60,8 @@ namespace NPCMapLocations
       drawPamHouseUpgrade = Game1.MasterPlayer.mailReceived.Contains("pamHouseUpgrade");
       drawMovieTheaterJoja = Utility.doesMasterPlayerHaveMailReceivedButNotMailForTomorrow("ccMovieTheaterJoja");
       drawMovieTheater = Utility.doesMasterPlayerHaveMailReceivedButNotMailForTomorrow("ccMovieTheater");
-      drawIsland = true;
-      // drawIsland = Game1.MasterPlayer.hasOrWillReceiveMail("Visited_Island");
+      //drawIsland = true;
+      drawIsland = Game1.MasterPlayer.hasOrWillReceiveMail("Visited_Island");
       mapX = (int)center.X;
       mapY = (int)center.Y;
 
@@ -126,7 +126,7 @@ namespace NPCMapLocations
 
     public override void performHoverAction(int x, int y)
     {
-      var f = points;
+      //var f = points;
       hoveredLocationText = "";
       hoveredNames = "";
       hasIndoorCharacter = false;
@@ -157,11 +157,15 @@ namespace NPCMapLocations
           if (Game1.getMouseX() >= npcLocation.X && Game1.getMouseX() <= npcLocation.X + markerWidth &&
               Game1.getMouseY() >= npcLocation.Y && Game1.getMouseY() <= npcLocation.Y + markerHeight)
           {
-            if (!npcMarker.Value.IsHidden && !(npcMarker.Value.Type == Character.Horse))
+            if (!npcMarker.Value.IsHidden) //&& !(npcMarker.Value.Type == Character.Horse))
             {
               if (Customizations.Names.TryGetValue(npcMarker.Key, out var name))
               {
                 hoveredList.Add(name);
+              }
+              else if (npcMarker.Value.Type == Character.Horse)
+              {
+                hoveredList.Add(npcMarker.Key);
               }
             }
 
@@ -225,43 +229,41 @@ namespace NPCMapLocations
 
       if (!hoveredLocationText.Equals(""))
       {
-        IClickableMenu.drawHoverText(b, hoveredLocationText, Game1.smallFont, 0, 0, -1, null, -1, null, null, 0, -1, -1,
-          -1, -1, 1f, null);
         int textLength = (int)Game1.smallFont.MeasureString(hoveredLocationText).X + Game1.tileSize / 2;
         width = Math.Max((int)Game1.smallFont.MeasureString(hoveredLocationText).X + Game1.tileSize / 2, textLength);
         height = (int)Math.Max(60, Game1.smallFont.MeasureString(hoveredLocationText).Y + 5 * Game1.tileSize / 8);
-        if (x + width > Game1.viewport.Width)
+        if (x + width > Game1.uiViewport.Width)
         {
-          x = Game1.viewport.Width - width;
+          x = Game1.uiViewport.Width - width;
           y += Game1.tileSize / 4;
         }
 
         if (ModMain.Config.NameTooltipMode == 1)
         {
-          if (y + height > Game1.viewport.Height)
+          if (y + height > Game1.uiViewport.Height)
           {
             x += Game1.tileSize / 4;
-            y = Game1.viewport.Height - height;
+            y = Game1.uiViewport.Height - height;
           }
 
           offsetY = 2 - Game1.tileSize;
         }
         else if (ModMain.Config.NameTooltipMode == 2)
         {
-          if (y + height > Game1.viewport.Height)
+          if (y + height > Game1.uiViewport.Height)
           {
             x += Game1.tileSize / 4;
-            y = Game1.viewport.Height - height;
+            y = Game1.uiViewport.Height - height;
           }
 
           offsetY = height - 4;
         }
         else
         {
-          if (y + height > Game1.viewport.Height)
+          if (y + height > Game1.uiViewport.Height)
           {
             x += Game1.tileSize / 4;
-            y = Game1.viewport.Height - height;
+            y = Game1.uiViewport.Height - height;
           }
         }
 
@@ -269,6 +271,10 @@ namespace NPCMapLocations
         DrawNames(b, hoveredNames, x, y, offsetY, height, ModMain.Config.NameTooltipMode);
 
         // Draw location tooltip
+        IClickableMenu.drawHoverText(b, hoveredLocationText, Game1.smallFont);
+        //IClickableMenu.drawHoverText(b, hoveredLocationText, Game1.smallFont, 0, 0, -1, null, -1, null, null, 0, -1, -1,
+        //-1, -1, 1f, null);
+        /*
         IClickableMenu.drawTextureBox(b, Game1.menuTexture, new Rectangle(0, 256, 60, 60), x, y, width, height,
           Color.White, 1f, false);
         b.DrawString(Game1.smallFont, hoveredLocationText,
@@ -282,6 +288,7 @@ namespace NPCMapLocations
           Game1.textShadowColor);
         b.DrawString(Game1.smallFont, hoveredLocationText,
           new Vector2((float)(x + Game1.tileSize / 4), (float)(y + Game1.tileSize / 4 + 4)), Game1.textColor * 0.9f);
+          */
       }
       else
       {
@@ -516,9 +523,9 @@ namespace NPCMapLocations
 
         // If going off screen on the right, move tooltip to below location tooltip so it can stay inside the screen
         // without the cursor covering the tooltip
-        if (x + width > Game1.viewport.Width)
+        if (x + width > Game1.uiViewport.Width)
         {
-          x = Game1.viewport.Width - width;
+          x = Game1.uiViewport.Width - width;
           if (lines.Length > 1)
           {
             y += relocate - 8 + ((int)Game1.smallFont.MeasureString(names).Y) + Game1.tileSize / 2;
@@ -532,13 +539,13 @@ namespace NPCMapLocations
       else if (nameTooltipMode == 2)
       {
         y += offsetY;
-        if (x + width > Game1.viewport.Width)
+        if (x + width > Game1.uiViewport.Width)
         {
-          x = Game1.viewport.Width - width;
+          x = Game1.uiViewport.Width - width;
         }
 
         // If going off screen on the bottom, move tooltip to above location tooltip so it stays visible
-        if (y + height > Game1.viewport.Height)
+        if (y + height > Game1.uiViewport.Height)
         {
           x = Game1.getOldMouseX() + Game1.tileSize / 2;
           if (lines.Length > 1)
@@ -847,43 +854,51 @@ namespace NPCMapLocations
     }
     /// <summary>Get the ModMain.Map points to display on a map.</summary>
     /// vanilla locations that have to be tweaked to match modified map
-    private Dictionary<string, Rectangle> RegionRects() => new Dictionary<string, Rectangle>()
+    private Dictionary<string, Rectangle> RegionRects()
     {
-      {"Desert_Region", new Rectangle(-1, -1, 261, 175)},
-      {"Farm_Region", new Rectangle(-1, -1, 188, 148)},
-      {"Backwoods_Region", new Rectangle(-1, -1, 148, 120)},
-      {"BusStop_Region", new Rectangle(-1, -1, 76, 100)},
-      {"WizardHouse", new Rectangle(-1, -1, 36, 76)},
-      {"AnimalShop", new Rectangle(-1, -1, 76, 40)},
-      {"LeahHouse", new Rectangle(-1, -1, 32, 24)},
-      {"SamHouse", new Rectangle(-1, -1, 36, 52)},
-      {"HaleyHouse", new Rectangle(-1, -1, 40, 36)},
-      {"TownSquare", new Rectangle(-1, -1, 48, 45)},
-      {"Hospital", new Rectangle(-1, -1, 16, 32)},
-      {"SeedShop", new Rectangle(-1, -1, 28, 40)},
-      {"Blacksmith", new Rectangle(-1, -1, 80, 36)},
-      {"Saloon", new Rectangle(-1, -1, 28, 40)},
-      {"ManorHouse", new Rectangle(-1, -1, 44, 56)},
-      {"ArchaeologyHouse", new Rectangle(-1, -1, 32, 28)},
-      {"ElliottHouse", new Rectangle(-1, -1, 28, 20)},
-      {"Sewer", new Rectangle(-1, -1, 24, 20)},
-      {"Graveyard", new Rectangle(-1, -1, 40, 32)},
-      {"Trailer", new Rectangle(-1, -1, 20, 12)},
-      {"JoshHouse", new Rectangle(-1, -1, 36, 36)},
-      {"ScienceHouse", new Rectangle(-1, -1, 48, 32)},
-      {"Tent", new Rectangle(-1, -1, 12, 16)},
-      {"Mine", new Rectangle(-1, -1, 16, 24)},
-      {"AdventureGuild", new Rectangle(-1, -1, 32, 36)},
-      {"Quarry", new Rectangle(-1, -1, 88, 76)},
-      {"JojaMart", new Rectangle(-1, -1, 52, 52)},
-      {"FishShop", new Rectangle(-1, -1, 36, 40)},
-      {"Spa", new Rectangle(-1, -1, 48, 36)},
-      {"Woods", new Rectangle(-1, -1, 196, 176)},
-      {"RuinedHouse", new Rectangle(-1, -1, 20, 20)},
-      {"CommunityCenter", new Rectangle(-1, -1, 44, 36)},
-      {"SewerPipe", new Rectangle(-1, -1, 24, 32)},
-      {"Railroad_Region", new Rectangle(-1, -1, 180, 69)},
-      {"LonelyStone", new Rectangle(-1, -1, 28, 28)},
-    };
+      var rects = new Dictionary<string, Rectangle>()
+      {
+        {"Desert_Region", new Rectangle(-1, -1, 261, 175)},
+        {"Farm_Region", new Rectangle(-1, -1, 188, 148)},
+        {"Backwoods_Region", new Rectangle(-1, -1, 148, 120)},
+        {"BusStop_Region", new Rectangle(-1, -1, 76, 100)},
+        {"WizardHouse", new Rectangle(-1, -1, 36, 76)},
+        {"AnimalShop", new Rectangle(-1, -1, 76, 40)},
+        {"LeahHouse", new Rectangle(-1, -1, 32, 24)},
+        {"SamHouse", new Rectangle(-1, -1, 36, 52)},
+        {"HaleyHouse", new Rectangle(-1, -1, 40, 36)},
+        {"TownSquare", new Rectangle(-1, -1, 48, 45)},
+        {"Hospital", new Rectangle(-1, -1, 16, 32)},
+        {"SeedShop", new Rectangle(-1, -1, 28, 40)},
+        {"Blacksmith", new Rectangle(-1, -1, 80, 36)},
+        {"Saloon", new Rectangle(-1, -1, 28, 40)},
+        {"ManorHouse", new Rectangle(-1, -1, 44, 56)},
+        {"ArchaeologyHouse", new Rectangle(-1, -1, 32, 28)},
+        {"ElliottHouse", new Rectangle(-1, -1, 28, 20)},
+        {"Sewer", new Rectangle(-1, -1, 24, 20)},
+        {"Graveyard", new Rectangle(-1, -1, 40, 32)},
+        {"Trailer", new Rectangle(-1, -1, 20, 12)},
+        {"JoshHouse", new Rectangle(-1, -1, 36, 36)},
+        {"ScienceHouse", new Rectangle(-1, -1, 48, 32)},
+        {"Tent", new Rectangle(-1, -1, 12, 16)},
+        {"Mine", new Rectangle(-1, -1, 16, 24)},
+        {"AdventureGuild", new Rectangle(-1, -1, 32, 36)},
+        {"Quarry", new Rectangle(-1, -1, 88, 76)},
+        {"JojaMart", new Rectangle(-1, -1, 52, 52)},
+        {"FishShop", new Rectangle(-1, -1, 36, 40)},
+        {"Spa", new Rectangle(-1, -1, 48, 36)},
+        {"Woods", new Rectangle(-1, -1, 196, 176)},
+        {"RuinedHouse", new Rectangle(-1, -1, 20, 20)},
+        {"CommunityCenter", new Rectangle(-1, -1, 44, 36)},
+        {"SewerPipe", new Rectangle(-1, -1, 24, 32)},
+        {"Railroad_Region", new Rectangle(-1, -1, 180, 69)},
+        {"LonelyStone", new Rectangle(-1, -1, 28, 28)},
+      };
+      if (drawIsland)
+      {
+        rects.Add("GingerIsland", new Rectangle(-1, -1, 180, 160));
+      }
+      return rects;
+    }
   }
 }


### PR DESCRIPTION
…island mapping, etc

Split screen:
- Changed most non-static fields in ModMain.cs to PerScreen objects
- Split screen players will not add duplicate Events
- (Static variables are shared between host & split screen instances of the ModMain class. Removing/Adding the typing might need to be considered)

Multiplayer:
- Fixed errors resulting from messages being sent to players without SMAPI
- Remote players store the host ID to communicate with better
- Host stores remote player IDs to communicate with better
- Initialized FarmerMarkers regardless to fix errors when game switches to multiplayer mode and it was not initialized
- Added peer disconnect event to clean up player IDs

Rendering Calls:
- Changed Game1.viewport to Game1.uiViewport when drawing in UI mode for compatibility with UI scale
- Moved Debug Mode's tile highlight to RenderedWorld to avoid UI mode
- Fixed hovered location text being drawn twice (Not sure if the double draws were originally meant to fix something else)

Island Mapping:
- Added entries of the Island maps to MapVectors in ModConstants
- Added a GingerIsland MapVector and conditional RegionRect to display the Island hover text

Etc:
- Added Birdie & Leo icon offsets
- Horse markers are always drawn with hover text available to be multiple horse friendly
- Fixed horse marker not updated when the host is riding the horse