### PR TITLE
Fix 'object disposed' errors in the upcoming SMAPI 3.9.2

### DIFF
--- a/NPCMapLocations/ModMain.cs
+++ b/NPCMapLocations/ModMain.cs
@@ -458,11 +458,14 @@ namespace NPCMapLocations
 
             try
             {
-              newMarker.Sprite = new AnimatedSprite($"Characters\\{name}", 0, 16, 32).Texture;
+              newMarker.Sprite = new AnimatedSprite(npc.Sprite.textureName.Value, 0, 16, 32).Texture;
             }
-            catch
+            catch (Exception ex)
             {
-              newMarker.Sprite = npc.Sprite.Texture;
+              this.Monitor.Log($"Couldn't load marker for NPC '{npc.Name}'; using the default sprite instead.", LogLevel.Warn);
+              this.Monitor.Log(ex.ToString());
+
+              newMarker.Sprite = new AnimatedSprite($@"Characters\{(npc.Gender == NPC.male ? "maleRival" : "femaleRival")}", 0, 16, 32).Texture;
             }
 
             NpcMarkers.Value.Add(npc.Name, newMarker);


### PR DESCRIPTION
SMAPI will dispose some assets more aggressively, so caching a direct reference to an NPC's sprite texture is unsafe. This commit fixes that by loading the sprite's texture name (instead of a hardcoded asset path) so we rarely need the fallback logic, and falling back to a placeholder sprite with a warning if that fails.