### PR TITLE
Fix error when a location has invalid warp targets

### DIFF
--- a/LocationUtil/LocationUtil.cs
+++ b/LocationUtil/LocationUtil.cs
@@ -102,12 +102,12 @@ internal class LocationUtil
       if (currLocationName == warp.TargetName || prevLocationName == warp.TargetName) continue;
 
       var warpLocation = Game1.getLocationFromName(warp.TargetName);
+      if (warpLocation == null)
+        continue;
 
       // If one of the warps is a root location, current location is an indoor building 
       if (warpLocation.IsOutdoors)
-      {
         hasOutdoorWarp = true;
-      }
 
       // If all warps are indoors, then the current location is a room
       LocationContexts[currLocationName].Type = hasOutdoorWarp ? LocationType.Building : LocationType.Room;


### PR DESCRIPTION
`LocationUtil.MapRootLocations` crashes if a warp target doesn't match any location (see [example log](https://smapi.io/log/da9aacdcb51c4b8c9fb6269f6e4fa7e0)). This PR makes it skip invalid warps instead.